### PR TITLE
Fix ZohoOAuthException for PHP 8

### DIFF
--- a/lib/zoho/oauth/Exception/ZohoOAuthException.php
+++ b/lib/zoho/oauth/Exception/ZohoOAuthException.php
@@ -6,17 +6,6 @@ use Exception;
 class ZohoOAuthException extends Exception
 {
 
-    protected $message = 'Unknown exception';
-
-    // Exception message
-    protected $code = 0;
-
-    // Unknown
-    protected $file;
-
-    // User-defined exception code
-    protected $line;
-
     // Source filename of exception
     private $string;
 


### PR DESCRIPTION
When a `ZohoOAuthException` happens, you will receive the following error:

`Type of Zoho\OAuth\Exception\ZohoOAuthException::$file must be string (as in class Exception)`

This PR fixes it.